### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Fourth example in AI agents series. Here, I build a customer MCP server to give 
 - [Video](https://youtu.be/N3vHJcHBS-w)
 - [Blog](https://medium.com/data-science-collective/model-context-protocol-mcp-explained-ef5c33c5fe05)
 
+<a href="https://glama.ai/mcp/servers/@ramaiyaKushal/mcp-learning">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ramaiyaKushal/mcp-learning/badge" alt="AVA Server MCP server" />
+</a>
+
 ## How to run this example
 
 1. Clone this repo


### PR DESCRIPTION
This PR adds a badge for the [AVA MCP Server](https://glama.ai/mcp/servers/@ramaiyaKushal/mcp-learning) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ramaiyaKushal/mcp-learning">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ramaiyaKushal/mcp-learning/badge" alt="AVA Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.